### PR TITLE
Fix secrets informer race condition on CertificateRequests controllers

### DIFF
--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",
+        "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_utils//clock:go_default_library",
     ],
 )


### PR DESCRIPTION

The CertificateRequests controllers are not waiting for the core secrets informer to be fully synced, leading to race conditions where the indexer does not contains the Secret being queried during the sign process.

This PR is adding a explicit condition into the `mustSync` list that will guarantee the secrets informer must be fully synced before the controller starts.